### PR TITLE
fix: shorten gauge needle length

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -647,7 +647,7 @@ body.nav-overlay-active .nav-backdrop {
   top: 50%;
   left: 50%;
   width: 3px;
-  height: 35%;
+  height: calc(35% - 6px);
   background: linear-gradient(to top, var(--color-brass-light), #ff6b35);
   transform-origin: bottom center;
   transform: translate(-50%, -100%) rotate(var(--needle-angle));


### PR DESCRIPTION
## Summary
- Shortens both gauge needles by 6px (`height: calc(35% - 6px)`) for better visual proportion

## Test plan
- [ ] Verify left gauge needle appears shorter and stays within gauge bounds
- [ ] Verify right gauge needle appears shorter and stays within gauge bounds
- [ ] Confirm needle animation still works correctly across scroll zones

🤖 Generated with [Claude Code](https://claude.com/claude-code)