### PR TITLE
fix: remove double-DPR scaling from sidebar glyph scissor

### DIFF
--- a/js/sidebar-hieroglyphs.js
+++ b/js/sidebar-hieroglyphs.js
@@ -249,7 +249,6 @@ function render() {
   if (!overlayScene || !overlayCamera || !mainRenderer) return;
   if (window.innerWidth < 768) return;
   const h = window.innerHeight;
-  const dpr = mainRenderer.getPixelRatio();
   mainRenderer.autoClear = false;
   mainRenderer.clearDepth();
 
@@ -263,10 +262,10 @@ function render() {
     if (!plane || !plane.visible || !el) continue;
     const rect = el.getBoundingClientRect();
     mainRenderer.setScissor(
-      rect.left * dpr,
-      (h - rect.bottom) * dpr,
-      rect.width * dpr,
-      rect.height * dpr
+      rect.left,
+      h - rect.bottom,
+      rect.width,
+      rect.height
     );
     mainRenderer.render(overlayScene, overlayCamera);
   }


### PR DESCRIPTION
## Summary
- Three.js `setScissor()` internally multiplies coordinates by the pixel ratio, but the sidebar render pass was also manually multiplying by DPR — causing a 2.25x scaling error on HiDPI displays
- This made glyph planes bleed past sidebar panels into the star field on macOS Retina (Safari/Atlas) where DPR is clamped to 1.5
- On Windows at 100% scaling (DPR=1), 1×1=1 so the bug was invisible

## Test plan
- [ ] Verify glyphs stay contained within sidebar panels on macOS Retina (Safari, Arc/Atlas)
- [ ] Verify no visual change on Windows at 100% display scaling
- [ ] Verify glyphs still render correctly at tablet breakpoint (768–1199px)
- [ ] Resize browser window and confirm no bleed at any width

🤖 Generated with [Claude Code](https://claude.com/claude-code)