### PR TITLE
fix: blank screen when tapping star in zone 3 on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1849,6 +1849,14 @@ body.nav-overlay-active .nav-backdrop {
     display: none;
   }
 
+  /* Fix: disable backdrop-filter on mobile to prevent iOS Safari GPU
+     compositing failure over WebGL canvas (causes blank screen) */
+  .overlay__backdrop {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: rgba(4, 5, 15, 0.92);
+  }
+
   /* T013: Mobile project overlay — full width */
   .overlay__frame {
     width: 100%;

--- a/js/panel.js
+++ b/js/panel.js
@@ -360,18 +360,24 @@ function closeProjectPanel() {
   document.body.style.position = '';
   document.body.style.width = '';
   document.body.style.top = '';
-  window.scrollTo(0, _savedScrollTop);
 
-  if (window.ScrollTrigger) {
-    window.ScrollTrigger.getAll().forEach(st => st.enable());
-  }
+  // Use rAF to let iOS Safari process style resets before restoring
+  // scroll position — prevents blank screen at deep scroll offsets (zone 3+)
+  requestAnimationFrame(() => {
+    window.scrollTo(0, _savedScrollTop);
 
-  document.dispatchEvent(new CustomEvent('panel-close'));
+    if (window.ScrollTrigger) {
+      window.ScrollTrigger.getAll().forEach(st => st.enable());
+      window.ScrollTrigger.refresh();
+    }
 
-  if (triggerElement && typeof triggerElement.focus === 'function') {
-    triggerElement.focus();
-  }
-  triggerElement = null;
+    document.dispatchEvent(new CustomEvent('panel-close'));
+
+    if (triggerElement && typeof triggerElement.focus === 'function') {
+      triggerElement.focus();
+    }
+    triggerElement = null;
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #19 — on mobile, scrolling to zone 3 and tapping a star causes a blank screen instead of opening the project panel.

**Root cause** (identified by multi-agent expert team):

Two iOS Safari issues combine at deep scroll offsets:

1. **`backdrop-filter: blur(8px)`** on `.overlay__backdrop` triggers GPU compositing failure when applied over a full-viewport WebGL canvas on mobile, causing blank/black rendering
2. **`body { position: fixed; top: -2000px }` scroll-lock pattern** — at zone 3's deep scroll offset (~2000px), iOS Safari fails to restore scroll position on panel close via `window.scrollTo()`, dumping the user back to scroll position 0 with no active zone (all stars dimmed = "blank" appearance)

Zone 3 is worst-affected because it has the deepest scroll offset, producing the largest negative `top` value.

**Fixes applied:**

- **css/styles.css**: Disable `backdrop-filter` on mobile (`<768px`), replace with more opaque solid background (`rgba(4,5,15,0.92)`) to maintain the visual dimming effect
- **js/panel.js**: Wrap scroll position restore + ScrollTrigger re-enable in `requestAnimationFrame` to give iOS Safari time to process style resets before scroll restoration
- **js/panel.js**: Add `ScrollTrigger.refresh()` after panel close to force scroll position recalculation

## Test plan
- [ ] On iPhone (iOS Safari): scroll to zone 3, tap a star — panel opens correctly, no blank screen
- [ ] Close panel — returns to correct scroll position in zone 3, stars visible
- [ ] Repeat for zones 1 and 2 — no regression
- [ ] Desktop: backdrop blur still works (only disabled on mobile)
- [ ] Verify panel open/close keyboard nav still works (Tab, Enter, Escape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)