### PR TITLE
fix: prevent FOUC flash before splash gate

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2255,6 +2255,10 @@ body.splash-active #app-shell {
   pointer-events: none;
 }
 
+html.splash-pending #app-shell {
+  visibility: hidden;
+}
+
 /* --- Backdrop (T006) --- */
 .splash-gate__backdrop {
   position: absolute;

--- a/index.html
+++ b/index.html
@@ -64,6 +64,14 @@
   </script>
 
   <link rel="stylesheet" href="css/styles.css">
+
+  <!-- Prevent FOUC: hide app-shell for first-time visitors before first paint -->
+  <script>
+    try {
+      var d = localStorage.getItem('oe-splash-dismissed');
+      if (!d || JSON.parse(d).v !== 1) document.documentElement.classList.add('splash-pending');
+    } catch(e) { document.documentElement.classList.add('splash-pending'); }
+  </script>
 </head>
 <body>
 

--- a/js/interactions.js
+++ b/js/interactions.js
@@ -323,7 +323,7 @@ function collapseTagline(btn) {
 function setInitialFocus() {
   const firstBtn = document.querySelector('#constellation-nav button[data-project-id]');
   if (firstBtn) {
-    firstBtn.focus();
+    firstBtn.focus({ focusVisible: true });
   }
 }
 

--- a/js/splash.js
+++ b/js/splash.js
@@ -219,7 +219,7 @@ function setupFocusTrap(rootEl, doorEl) {
       doorEl.click();
     }
   });
-  doorEl.focus();
+  doorEl.focus({ focusVisible: false });
 }
 
 // ---------------------------------------------------------------------------
@@ -304,6 +304,7 @@ export function init(options = {}) {
       // 5. Cleanup
       root.remove();
       document.body.classList.remove('splash-active');
+      document.documentElement.classList.remove('splash-pending');
 
       resolve();
     });


### PR DESCRIPTION
## Summary
- **FOUC fix**: Inline `<script>` in `<head>` checks localStorage and adds `splash-pending` class to `<html>` before first paint, hiding `#app-shell` via `visibility: hidden` for first-time visitors
- **Door focus ring**: Suppress yellow `:focus-visible` outline on splash door with `focus({ focusVisible: false })` — door is the only interactive element in the focus trap, doesn't need a ring
- **Nav focus ring preserved**: Use `focus({ focusVisible: true })` in `setInitialFocus()` to explicitly force the yellow outline on the first nav button after reveal, overriding the browser's inherited pointer modality

## Details
The flash occurred because `#app-shell` was visible in static HTML while the splash gate was built dynamically in JS. The `body.splash-active` class only disabled `pointer-events` but never hid the app shell visually.

The `focusVisible` options work together: suppressing focus-visible on the door sets the browser's modality to "pointer", which would normally propagate to suppress focus-visible on subsequent programmatic `.focus()` calls. The explicit `focusVisible: true` on the nav button overrides this inherited modality.

## Test plan
- [ ] First visit: no flash of portfolio content before splash gate appears
- [ ] First visit: no yellow border on the door during splash
- [ ] After door click + reveal: first nav item has yellow focus ring
- [ ] Keyboard nav (down arrow) from first nav item moves to second item
- [ ] Returning visit: portfolio loads immediately, no delay from splash-pending
- [ ] Clear localStorage, reload: splash gate appears without FOUC

🤖 Generated with [Claude Code](https://claude.com/claude-code)