### PR TITLE
fix: resolve iOS Safari blank screen on panel close at deep scroll

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -373,13 +373,8 @@ if (sceneReady) {
     initAutoTierDegradation(pp.composer, pp.bloomPass, pp.customPass);
   }
 
-  // Disable scroll when panel open, re-enable on close
-  document.addEventListener('panel-open', () => {
-    if (ScrollTrigger) ScrollTrigger.getAll().forEach(st => st.disable());
-  });
-  document.addEventListener('panel-close', () => {
-    if (ScrollTrigger) ScrollTrigger.getAll().forEach(st => st.enable());
-  });
+  // ScrollTrigger disable/enable is handled directly in panel.js open/close —
+  // duplicate listeners here caused double-enable without refresh on close.
 
   // T018: Hide right gauge when panel is open
   const gaugeRight = document.querySelector('.frame__gauge--right');

--- a/js/panel.js
+++ b/js/panel.js
@@ -370,21 +370,24 @@ function closeProjectPanel() {
   // of scroll-position-0 content during the 2-frame transition window.
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
-      window.scrollTo(0, _savedScrollTop);
-      overlayEl.setAttribute('hidden', '');
-      _isClosing = false;
+      try {
+        window.scrollTo(0, _savedScrollTop);
+        overlayEl.setAttribute('hidden', '');
 
-      if (window.ScrollTrigger) {
-        window.ScrollTrigger.getAll().forEach(st => st.enable());
-        window.ScrollTrigger.refresh();
+        if (window.ScrollTrigger) {
+          window.ScrollTrigger.getAll().forEach(st => st.enable());
+          window.ScrollTrigger.refresh();
+        }
+
+        document.dispatchEvent(new CustomEvent('panel-close'));
+
+        if (triggerElement && typeof triggerElement.focus === 'function') {
+          triggerElement.focus();
+        }
+        triggerElement = null;
+      } finally {
+        _isClosing = false;
       }
-
-      document.dispatchEvent(new CustomEvent('panel-close'));
-
-      if (triggerElement && typeof triggerElement.focus === 'function') {
-        triggerElement.focus();
-      }
-      triggerElement = null;
     });
   });
 }

--- a/js/panel.js
+++ b/js/panel.js
@@ -38,6 +38,7 @@ let _beforeOpen = null;
 
 /** Saved scroll position for iOS-safe scroll lock */
 let _savedScrollTop = 0;
+let _isClosing = false;
 
 /** Repo metrics data (passed via DI from app.js) */
 let _repoMetrics = { repos: {} };
@@ -342,7 +343,8 @@ function showProjectPanel(project, trigger) {
 // closeProjectPanel
 // ---------------------------------------------------------------------------
 function closeProjectPanel() {
-  if (!overlayEl || overlayEl.hasAttribute('hidden')) return;
+  if (!overlayEl || overlayEl.hasAttribute('hidden') || _isClosing) return;
+  _isClosing = true;
 
   const videos = overlayEl.querySelectorAll('video');
   videos.forEach(v => {
@@ -354,29 +356,36 @@ function closeProjectPanel() {
   const mediaZone = overlayEl.querySelector('.overlay__media-zone');
   mediaZone.innerHTML = '';
 
-  overlayEl.setAttribute('hidden', '');
-
+  // Body style reset — overlay stays visible as a cover during the transition
   document.documentElement.style.overflow = '';
   document.body.style.position = '';
   document.body.style.width = '';
   document.body.style.top = '';
 
-  // Use rAF to let iOS Safari process style resets before restoring
-  // scroll position — prevents blank screen at deep scroll offsets (zone 3+)
+  // Double rAF: iOS Safari needs two frames to commit body style resets
+  // and rebuild compositing layers before scroll restoration is safe.
+  // Single rAF (cdf162c) was insufficient — Safari's rendering pipeline
+  // drops the WebGL canvas compositing layer during the body position thrash.
+  // The overlay stays visible until scrollTo completes to prevent a flash
+  // of scroll-position-0 content during the 2-frame transition window.
   requestAnimationFrame(() => {
-    window.scrollTo(0, _savedScrollTop);
+    requestAnimationFrame(() => {
+      window.scrollTo(0, _savedScrollTop);
+      overlayEl.setAttribute('hidden', '');
+      _isClosing = false;
 
-    if (window.ScrollTrigger) {
-      window.ScrollTrigger.getAll().forEach(st => st.enable());
-      window.ScrollTrigger.refresh();
-    }
+      if (window.ScrollTrigger) {
+        window.ScrollTrigger.getAll().forEach(st => st.enable());
+        window.ScrollTrigger.refresh();
+      }
 
-    document.dispatchEvent(new CustomEvent('panel-close'));
+      document.dispatchEvent(new CustomEvent('panel-close'));
 
-    if (triggerElement && typeof triggerElement.focus === 'function') {
-      triggerElement.focus();
-    }
-    triggerElement = null;
+      if (triggerElement && typeof triggerElement.focus === 'function') {
+        triggerElement.focus();
+      }
+      triggerElement = null;
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- **Double rAF** in `closeProjectPanel()` — iOS Safari needs two compositing frames to rebuild GPU layers after the `body position:fixed → static` thrash. Single rAF (`cdf162c`) was insufficient.
- **Overlay stays visible** during the 2-frame transition as a visual cover, preventing a flash of scroll-position-0 content. Hidden attribute is now deferred to after `scrollTo`.
- **`_isClosing` guard** replaces the `hidden` attribute as the re-entrancy check since `hidden` is deferred.
- **Remove duplicate ScrollTrigger listeners** in `app.js` — `panel.js` already handles disable/enable in both open paths (cluster + regular) and close. The duplicates caused double-enable without `refresh()`.

## Root Cause Analysis

The blank screen at deep scroll (zone 3+) on iOS Safari is caused by:
1. Body `position: fixed → static` triggers GPU compositing layer teardown
2. The WebGL canvas (`#orb-canvas`) loses its compositing layer during the thrash
3. Single rAF only gives Safari one frame to recomposite — insufficient
4. Duplicate `ScrollTrigger.enable()` in `app.js` fired without `refresh()`, leaving triggers with stale positions

## Test plan

- [ ] **iOS Safari (critical)**: Open a star panel in zone 3, close it — no blank screen
- [ ] **iOS Safari**: Open a cluster panel, close it — no blank screen  
- [ ] **iOS Safari**: Rapid open-close-open — no stuck state
- [ ] **Desktop Chrome/Firefox**: Panel open/close at all scroll depths
- [ ] **Gauge hide/show**: Right gauge hides when panel opens, shows when closed
- [ ] **Focus restoration**: After close, focus returns to the triggering star
- [ ] **Keyboard**: Escape closes panel, Tab stays trapped while open

🤖 Generated with [Claude Code](https://claude.com/claude-code)