### PR TITLE
fix: disable mobile starfield scrolling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1849,6 +1849,11 @@ body.nav-overlay-active .nav-backdrop {
     display: none;
   }
 
+  /* Disable scroll driver on mobile — no scroll zones */
+  #scroll-driver {
+    display: none;
+  }
+
   /* Fix: disable backdrop-filter on mobile to prevent iOS Safari GPU
      compositing failure over WebGL canvas (causes blank screen) */
   .overlay__backdrop {

--- a/js/constellation-lines.js
+++ b/js/constellation-lines.js
@@ -318,6 +318,22 @@ function killShowcase() {
 
 // init — SVG container, defs, watermark, wire events (T028-T035)
 function init() {
+  if (window.innerWidth < 768) {
+    // Mobile: no constellation lines. Lazy-init on resize to desktop.
+    window.addEventListener('resize', onResizeDesktop);
+    return;
+  }
+  bootstrapLines();
+}
+
+// Lazy-init constellation lines when viewport grows past mobile width
+function onResizeDesktop() {
+  if (window.innerWidth < 768 || svgContainer) return;
+  window.removeEventListener('resize', onResizeDesktop);
+  bootstrapLines();
+}
+
+function bootstrapLines() {
   const ns = 'http://www.w3.org/2000/svg';
   svgContainer = document.createElementNS(ns, 'svg');
   svgContainer.setAttribute('class', 'constellation-lines');

--- a/js/scroll-zones.js
+++ b/js/scroll-zones.js
@@ -33,6 +33,18 @@ function init({ starNodes: sn, nebulaLayers: nl, nebulaGroup: ng, getCurrentTier
   nebulaGroup = ng;
   getCurrentTier = gt;
   gaugeInit(gt);           // T012-T015: gauge animations, dome parallax, reduced-motion
+  if (isMobileView()) {
+    // Mobile: no scroll zones, tap stars directly. Lazy-init on resize to desktop.
+    window.addEventListener('resize', onResizeDesktop);
+    return;
+  }
+  initScrollZones();
+}
+
+// Lazy-init scroll zones when viewport grows past mobile width (e.g. rotation)
+function onResizeDesktop() {
+  if (isMobileView() || scrollEnabled) return;
+  window.removeEventListener('resize', onResizeDesktop);
   initScrollZones();
 }
 


### PR DESCRIPTION
## Summary
- Disable scroll-zone and constellation-line initialization on mobile (<768px) to eliminate the entire class of ScrollTrigger/touch timing bugs that caused black screens after panel close
- Both modules register self-removing resize listeners so desktop functionality recovers if the viewport later crosses 768px (rotation, window resize)
- CSS defense-in-depth hides `#scroll-driver` on mobile

## What changed (3 files, +33 lines)
| File | Change |
|------|--------|
| `js/scroll-zones.js` | Early return after `gaugeInit()` on mobile; `onResizeDesktop` lazy-init with `scrollEnabled` guard |
| `js/constellation-lines.js` | Early return on mobile; `onResizeDesktop` lazy-init with `svgContainer` guard; extracted `bootstrapLines()` |
| `css/styles.css` | `#scroll-driver { display: none }` in mobile media query |

## What stays untouched
- **panel.js** — all scroll ops become no-ops (empty ScrollTrigger array, zero scroll position)
- **touch-guard.js** — still needed for iOS rubber-band overscroll
- **scene.js** — touch handling / raycasting independent of scroll zones
- **app.js** — calls both inits; they self-guard on mobile

## Test plan
- [ ] Mobile (<768px): page does not scroll, no `scroll-enabled` class on body
- [ ] Mobile: star tap → panel opens (no black screen)
- [ ] Mobile: panel close → starfield visible (no black screen)
- [ ] Mobile: hamburger nav works, no "Scroll to explore" button
- [ ] Mobile: no constellation lines SVG in DOM
- [ ] Mobile → rotate/resize to desktop: scroll zones and constellation lines initialize
- [ ] Desktop (>768px): scroll zones, constellation lines, panel open/close all work unchanged
- [ ] iOS Safari: no black screen on any interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)